### PR TITLE
Install from source using the install script on Mac/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@
   </a>
 </p>
 
-[![Solana crate](https://img.shields.io/crates/v/solana-core.svg)](https://crates.io/crates/solana-core)
 [![Solana documentation](https://docs.rs/solana-core/badge.svg)](https://docs.rs/solana-core)
-[![Build status](https://badge.buildkite.com/8cc350de251d61483db98bdfc895b9ea0ac8ffa4a32ee850ed.svg?branch=master)](https://buildkite.com/solana-labs/solana/builds?branch=master)
-[![codecov](https://codecov.io/gh/solana-labs/solana/branch/master/graph/badge.svg)](https://codecov.io/gh/solana-labs/solana)
+
+# Installing
+
+To install the latest Xolana release on Linux (Red Hat or Ubuntu) or macOS, follow these steps. macOS users must first install Homebrew.
+
+```shell
+curl https://raw.githubusercontent.com/jacklevin74/xolana/xolana/install/solana-install-init.sh | sh
+```
 
 # Building
 
@@ -47,7 +52,7 @@ $ sudo dnf install openssl-devel systemd-devel pkg-config zlib-devel llvm clang 
 ## **2. Download the source code.**
 
 ```bash
-$ git clone https://github.com/solana-labs/solana.git
+$ git clone https://github.com/jacklevin74/xolana.git
 $ cd solana
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 To install the latest Xolana release on Linux (Red Hat or Ubuntu) or macOS, follow these steps. macOS users must first install Homebrew.
 
 ```shell
-curl https://raw.githubusercontent.com/jacklevin74/xolana/xolana/install/solana-install-init.sh | sh
+curl https://raw.githubusercontent.com/jacklevin74/xolana/xolana/install/solana-install-init.sh | sudo bash
 ```
 
 # Building

--- a/install/solana-install-init.sh
+++ b/install/solana-install-init.sh
@@ -3,7 +3,7 @@
 { # this ensures the entire script is downloaded #
 
 RELEASE="${VARIABLE:-xolana}"
-GH_LATEST_TARBALL="https://api.github.com/repos/nibty/xolana/tarball/$RELEASE"
+GH_LATEST_TARBALL="https://api.github.com/repos/jacklevin74/xolana/tarball/$RELEASE"
 INSTALL_DIR="$HOME/.local/share/xolana/releases/$RELEASE"
 
 set -e

--- a/install/solana-install-init.sh
+++ b/install/solana-install-init.sh
@@ -1,187 +1,69 @@
-#!/bin/sh
-# Copyright 2016 The Rust Project Developers. See the COPYRIGHT
-# file at the top-level directory of this distribution and at
-# http://rust-lang.org/COPYRIGHT.
-#
-# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-# option. This file may not be copied, modified, or distributed
-# except according to those terms.
-
-# This is just a little script that can be downloaded from the internet to
-# install solana-install. It just does platform detection, downloads the installer
-# and runs it.
+#!/bin/bash
 
 { # this ensures the entire script is downloaded #
 
-if [ -z "$SOLANA_DOWNLOAD_ROOT" ]; then
-    SOLANA_DOWNLOAD_ROOT="https://github.com/solana-labs/solana/releases/download/"
-fi
-GH_LATEST_RELEASE="https://api.github.com/repos/solana-labs/solana/releases/latest"
+RELEASE="${VARIABLE:-xolana}"
+GH_LATEST_TARBALL="https://api.github.com/repos/nibty/xolana/tarball/$RELEASE"
+INSTALL_DIR="$HOME/.local/share/xolana/releases/$RELEASE"
 
 set -e
+sudo_cmd=$(which sudo &>/dev/null || true)
 
-usage() {
-    cat 1>&2 <<EOF
-solana-install-init
-initializes a new installation
+# Install dependencies
+printf "\nInstalling dependencies\n\n"
+if [[ "$OSTYPE" == "linux-gnu"* ]] && command -v apt &> /dev/null; then
+	echo "Installing dependencies for apt package manager. You may need to enter your password."
+	$sudo_cmd apt update
+	$sudo_cmd apt -y install \
+                build-essential \
+                pkg-config \
+                libudev-dev \
+                llvm \
+                libclang-dev \
+                curl \
+                protobuf-compiler
 
-USAGE:
-    solana-install-init [FLAGS] [OPTIONS] --data_dir <PATH> --pubkey <PUBKEY>
+elif [[ "$OSTYPE" == "linux-gnu"* ]] && command -v yum &> /dev/null; then
+	echo "Installing dependencies for yum package manager. You may need to enter your password."
+	$sudo_cmd yum install -y \
+								perl \
+								clang-devel \
+								pkg-config \
+								libudev-devel \
+								openssl \
+								openssl-devel \
+								curl \
+								protobuf-compiler
 
-FLAGS:
-    -h, --help              Prints help information
-        --no-modify-path    Don't configure the PATH environment variable
+elif command -v brew &> /dev/null; then
+	brew install pkg-config protobuf llvm coreutils
 
-OPTIONS:
-    -d, --data-dir <PATH>    Directory to store install data
-    -u, --url <URL>          JSON RPC URL for the solana cluster
-    -p, --pubkey <PUBKEY>    Public key of the update manifest
-EOF
-}
+else
+	echo "Could not find package manager to install dependencies (yum, apt, brew). Please install: pkg-config, libssl-dev, protobuf, llvm, coreutils"
+	exit 1
+fi
 
-main() {
-    downloader --check
-    need_cmd uname
-    need_cmd mktemp
-    need_cmd chmod
-    need_cmd mkdir
-    need_cmd rm
-    need_cmd sed
-    need_cmd grep
+# Install Rustup
+printf "\nInstalling Rustup\n\n"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+. "$HOME/.cargo/env"
 
-    for arg in "$@"; do
-      case "$arg" in
-        -h|--help)
-          usage
-          exit 0
-          ;;
-        *)
-          ;;
-      esac
-    done
+# Download Xolana
+printf "\nDownloading Xolana's source from $GH_LATEST_TARBALL\n\n"
+mkdir -p $INSTALL_DIR
+curl -L "$GH_LATEST_TARBALL" | tar xz --strip-components=1 -C $INSTALL_DIR
 
-    _ostype="$(uname -s)"
-    _cputype="$(uname -m)"
+# Build Xolana
+printf "\nBuilding Xolana: $INSTALL_DIR\n\n"
+cd $INSTALL_DIR
+cargo build --release
 
-    case "$_ostype" in
-    Linux)
-      _ostype=unknown-linux-gnu
-      ;;
-    Darwin)
-      if [[ $_cputype = arm64 ]]; then
-        _cputype=aarch64
-      fi
-      _ostype=apple-darwin
-      ;;
-    *)
-      err "machine architecture is currently unsupported"
-      ;;
-    esac
-    TARGET="${_cputype}-${_ostype}"
-
-    temp_dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t solana-install-init)"
-    ensure mkdir -p "$temp_dir"
-
-    # Check for SOLANA_RELEASE environment variable override.  Otherwise fetch
-    # the latest release tag from github
-    if [ -n "$SOLANA_RELEASE" ]; then
-      release="$SOLANA_RELEASE"
-    else
-      release_file="$temp_dir/release"
-      printf 'looking for latest release\n' 1>&2
-      ensure downloader "$GH_LATEST_RELEASE" "$release_file"
-      release=$(\
-        grep -m 1 \"tag_name\": "$release_file" \
-        | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p' \
-      )
-      if [ -z "$release" ]; then
-        err 'Unable to figure latest release'
-      fi
-    fi
-
-    download_url="$SOLANA_DOWNLOAD_ROOT/$release/solana-install-init-$TARGET"
-    solana_install_init="$temp_dir/solana-install-init"
-
-    printf 'downloading %s installer\n' "$release" 1>&2
-
-    ensure mkdir -p "$temp_dir"
-    ensure downloader "$download_url" "$solana_install_init"
-    ensure chmod u+x "$solana_install_init"
-    if [ ! -x "$solana_install_init" ]; then
-        printf '%s\n' "Cannot execute $solana_install_init (likely because of mounting /tmp as noexec)." 1>&2
-        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./solana-install-init." 1>&2
-        exit 1
-    fi
-
-    if [ -z "$1" ]; then
-      #shellcheck disable=SC2086
-      ignore "$solana_install_init" $SOLANA_INSTALL_INIT_ARGS
-    else
-      ignore "$solana_install_init" "$@"
-    fi
-    retval=$?
-
-    ignore rm "$solana_install_init"
-    ignore rm -rf "$temp_dir"
-
-    return "$retval"
-}
-
-err() {
-    printf 'solana-install-init: %s\n' "$1" >&2
-    exit 1
-}
-
-need_cmd() {
-    if ! check_cmd "$1"; then
-        err "need '$1' (command not found)"
-    fi
-}
-
-check_cmd() {
-    command -v "$1" > /dev/null 2>&1
-}
-
-# Run a command that should never fail. If the command fails execution
-# will immediately terminate with an error showing the failing
-# command.
-ensure() {
-    if ! "$@"; then
-      err "command failed: $*"
-    fi
-}
-
-# This is just for indicating that commands' results are being
-# intentionally ignored. Usually, because it's being executed
-# as part of error handling.
-ignore() {
-    "$@"
-}
-
-# This wraps curl or wget. Try curl first, if not installed,
-# use wget instead.
-downloader() {
-    if check_cmd curl; then
-        program=curl
-    elif check_cmd wget; then
-        program=wget
-    else
-        program='curl or wget' # to be used in error message of need_cmd
-    fi
-
-    if [ "$1" = --check ]; then
-        need_cmd "$program"
-    elif [ "$program" = curl ]; then
-        curl -sSfL "$1" -o "$2"
-    elif [ "$program" = wget ]; then
-        wget "$1" -O "$2"
-    else
-        err "Unknown downloader"   # should not reach here
-    fi
-}
-
-main "$@"
+printf "\nXolana has been built successfully\n\n"
+echo "Before running Xolana, you need to add the binaries to your PATH. You can do this by running the following command:"
+echo "export PATH=$INSTALL_DIR/target/release:\$PATH"
+echo
+echo "To permanently add the binaries to your PATH, you need to add the following line to your shell rc file. (~/.bashrc, ~/.zshrc, etc.)"
+echo "export PATH=$INSTALL_DIR/target/release:\$PATH"
+echo
 
 } # this ensures the entire script is downloaded #


### PR DESCRIPTION
#### Summary of Changes

Adds an easy to use command to install from source. Works on MacOS w/ brew and Linux w/ apt/yum.

curl https://raw.githubusercontent.com/jacklevin74/xolana/xolana/install/solana-install-init.sh | sh

> Working Example
```
curl https://raw.githubusercontent.com/nibty/xolana/xolana/install/solana-install-init.sh | sudo bash
```